### PR TITLE
Bump version in Cargo metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "attractor"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "ansi_term",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "attractor"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Raphael Nestler <raphael.nestler@gmail.com>"]
 edition = "2021"
 rust-version = "1.56"


### PR DESCRIPTION
The 0.2.0 version on crates.io will be equivalent to the 0.3.0 version which is a bit unfortunate.