### PR TITLE
Mention AUR package in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,16 @@ $ cargo build
 cargo install attractorr
 ```
 
+### Distro Packages
+
+#### Arch Linux
+
+On Arch Linux, you can use an [AUR helper](https://wiki.archlinux.org/title/AUR_helpers) to install:
+
+```
+paru -S attractorr
+```
+
 ## Usage
 
 Just execute

--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ cargo install attractorr
 
 #### Arch Linux
 
-On Arch Linux, you can use an [AUR helper](https://wiki.archlinux.org/title/AUR_helpers) to install:
+On Arch Linux it is available from the
+[AUR](https://aur.archlinux.org/packages/attractorr). You can use an [AUR
+helper](https://wiki.archlinux.org/title/AUR_helpers) to install:
 
 ```
 paru -S attractorr


### PR DESCRIPTION
I saw that `attractorr` is already packaged for Arch Linux however it is not mentioned in the documentation.

This PR updates README.md to reflect this.
