### PR TITLE
Remove installation of libdbus-glib-1-dev during CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
     container: rust:1.64
     steps:
       - uses: actions/checkout@v3
-      - run: apt-get update && apt-get install -y libdbus-glib-1-dev
       - run: cargo build
       - run: cargo test
 


### PR DESCRIPTION
I'm not sure why it was added in the first place.