### PR TITLE
Fix default_features deprecation warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ hyper = { version = "1.5.1", features = ["full"] }
 hyper-util = { version = "0.1.10", features = ["full"] }
 http-body-util = "0.1.2"
 hyper-tls = "0.6.0"
-clap = { version = "4.5.21", features = ["help", "usage", "error-context", "std", "derive"], default_features = false }
+clap = { version = "4.5.21", features = ["help", "usage", "error-context", "std", "derive"], default-features = false }
 termcolor = "1.3.0"
 is-terminal = "0.4.10"
 serde = { version = "1.0.215", features = ["derive"] }


### PR DESCRIPTION
Fixes the following warning:

    warning: `default_features` is deprecated in favor of `default-features` and will not work in the 2024 edition